### PR TITLE
Fix VSCode launch.json setting

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceRoot}/bin/Debug/netcoreapp1.0/AspNetFromScratchRTM.dll",
+            "program": "${workspaceRoot}/bin/Debug/netcoreapp1.0/AspNetCoreFromScratchSample.dll",
             "args": [],
             "cwd": "${workspaceRoot}",
             "stopAtEntry": false,


### PR DESCRIPTION
The `dotnet build` output main assembly file by using their project folder name.  So the default assembly should be `${workspaceRoot}/bin/Debug/netcoreapp1.0/AspNetCoreFromScratchSample.dll`.
